### PR TITLE
display totals for mAh, KMs, mins --- by wowi69

### DIFF
--- a/render.h
+++ b/render.h
@@ -1,4 +1,4 @@
-#pragma once
+//#pragma once
 
 #include "bcm_host.h"
 #include <stdio.h>
@@ -24,6 +24,8 @@
 #include <fontinfo.h>
 #include <time.h>
 #include "telemetry.h"
+#include <fontinfo.h>
+#include <time.h>
 
 #define TO_DEG 180.0f / M_PI
 
@@ -47,6 +49,12 @@ void draw_message(int severity, char line1[30], char line2[30], char line3[30], 
 //this will only indicate how much % are left. Mavlink specific, but could be used with others as well.
 void draw_batt_gauge(int remaining, float pos_x, float pos_y, float scale);
 void draw_batt_status(float voltage, float current, float pos_x, float pos_y, float scale);
+
+// totals
+void draw_TOTAL_AMPS(float current, float pos_x, float pos_y, float scale);
+void draw_TOTAL_DIST(int gpsspeed, float pos_x, float pos_y, float scale);
+void draw_TOTAL_TIME(int gpsspeed, float pos_x, float pos_y, float scale); 
+
 void draw_position(float lat, float lon, float pos_x, float pos_y, float scale);
 void draw_sat(int sats, int fixtype, float pos_x, float pos_y, float scale);
 void draw_home_distance(int distance, bool home_fixed, float pos_x, float pos_y, float scale);


### PR DESCRIPTION
This should be good.
If it's wrong, that means that the [original PR](https://github.com/rodizio1/EZ-WifiBroadcast/pull/160/commits/bd4e0281e7668f1b97ebff5f1fb162d6d7c12734) is wrong.
Be careful, you have to click the symbols on the left line number column to see all the code ...